### PR TITLE
Use new appimagetool, add zsync updates and automate CI

### DIFF
--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -1,0 +1,13 @@
+name: Github Action with a cronjob trigger
+on:
+  schedule:
+    - cron: "0 0 * * *"
+permissions:
+  actions: write
+jobs:
+  cronjob-based-github-action:
+    name: Cronjob based github action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,26 +1,28 @@
 name: Release
-on: workflow_dispatch
+on:
+  schedule:
+    - cron: "0 16 1/7 * *"
+  workflow_dispatch:
 permissions: write-all
-
 
 jobs:
   AppImage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: fuse
       run: |
           sudo apt-get update
-          sudo apt-get -y install libfuse2
+          sudo apt-get -y install libfuse2 zsync desktop-file-utils
     - name: Download Binary
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         chmod +x build.sh
         ./build.sh
-        
+
     - name: Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: floorp.AppImage
         path: 'dist'
@@ -34,4 +36,3 @@ jobs:
         files: |
           dist/
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ wget --retry-connrefused --tries=30 "$FLOORP_URL"
 wget --retry-connrefused --tries=30 "$APPIMAGETOOL" -O ./appimagetool
 tar -xvf *.tar.* && rm -f *.tar.*
 mv floorp/* "$APPDIR"/
-chmod +x ./AppDir/AppRun
+chmod +x ./AppDir/AppRun ./appimagetool
 echo "AppDir: $APPDIR"
 ls -al
 ls -al "$APPDIR"

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ export ARCH="$(uname -m)"
 export APPIMAGE_EXTRACT_AND_RUN=1
 APPDIR="$(realpath ./AppDir)"
 APPIMAGETOOL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-"$ARCH".AppImage"
-UPINFO="gh-releases-zsync|$(echo $GITHUB_REPOSITORY | tr '/' '|')|continuous|*$ARCH.AppImage.zsync"
+UPINFO="gh-releases-zsync|$(echo $GITHUB_REPOSITORY | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 
 FLOORP_URL="$(wget -q https://api.github.com/repos/floorp-Projects/Floorp/releases/latest -O - \
 	| sed 's/[()",{} ]/\n/g' | grep -oi "https.*linux-$ARCH.tar.bz2$" | head -1)"

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ FLOORP_URL="$(wget -q https://api.github.com/repos/floorp-Projects/Floorp/releas
 VERSION="$(echo $FLOORP_URL | awk -F"/" '{print $(NF-1)}')"
 
 wget --retry-connrefused --tries=30 "$FLOORP_URL"
-wget --retry-connrefused --tries=30 "$APPIMAGETOO" -O ./appimagetool
+wget --retry-connrefused --tries=30 "$APPIMAGETOOL" -O ./appimagetool
 tar -xvf *.tar.* && rm -f *.tar.*
 mv floorp/* "$APPDIR"/
 chmod +x ./AppDir/AppRun


### PR DESCRIPTION
The new [appimagetool](https://github.com/AppImage/appimagetool) uses the static appimage runtime by default, which means no more libfuse2 dependency.

It also uses zstd compression, which makes the appimage smaller while having a faster startup time.

The zsync file is for updates with [appimageupdate](https://github.com/AppImageCommunity/AppImageUpdate).

And the CI will automatically run every 7 days.